### PR TITLE
Add color wheel for terminal

### DIFF
--- a/src/components/ColorWheel.tsx
+++ b/src/components/ColorWheel.tsx
@@ -1,0 +1,38 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Palette } from 'lucide-react';
+
+export default function ColorWheel() {
+  const [color, setColor] = useState('#22c55e');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const style = getComputedStyle(document.documentElement);
+    const current = style.getPropertyValue('--terminal').trim();
+    if (current) {
+      setColor(current);
+    }
+  }, []);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setColor(value);
+    document.documentElement.style.setProperty('--terminal', value);
+  };
+
+  return (
+    <>
+      <Palette
+        aria-label="Pick terminal color"
+        className="w-5 h-5 cursor-pointer text-terminal"
+        onClick={() => inputRef.current?.click()}
+      />
+      <input
+        ref={inputRef}
+        type="color"
+        value={color}
+        onChange={handleChange}
+        className="hidden"
+      />
+    </>
+  );
+}

--- a/src/components/MacBar.tsx
+++ b/src/components/MacBar.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Maximize2, Minimize2, MessageCircleCode, X } from 'lucide-react';
+import ColorWheel from './ColorWheel';
 import { Link } from 'react-router';
 
 type MacBarProps = {
@@ -42,7 +43,7 @@ export default function MacBar({ fullscreenRef }: MacBarProps) {
       <span className="w-3 h-3 bg-yellow-400 rounded-full" />
 
       <button
-        className="flex items-center justify-center w-3 h-3 bg-green-500 rounded-full"
+        className="flex items-center justify-center w-3 h-3 bg-terminal rounded-full"
         onClick={handleToggleFullscreen}
       >
         {isFullscreen ? (
@@ -55,6 +56,10 @@ export default function MacBar({ fullscreenRef }: MacBarProps) {
       <span className="absolute font-mono font-bold text-gray-300 -translate-x-1/2 left-1/2">
         tomasp.me
       </span>
+
+      <div className="ml-auto">
+        <ColorWheel />
+      </div>
 
     </div>
   );

--- a/src/components/MainButton.tsx
+++ b/src/components/MainButton.tsx
@@ -9,7 +9,7 @@ type MainButtonProps = {
 export function MainButton({ children, link }: MainButtonProps) {
   return (
     <Link to={link}>
-<button className="inline-flex items-center gap-2 px-4 py-2 font-mono text-sm transition rounded-sm sm:text-base text-terminal hover:bg-green-600 hover:text-black">
+<button className="inline-flex items-center gap-2 px-4 py-2 font-mono text-sm transition rounded-sm sm:text-base text-terminal hover:bg-terminal hover:text-black">
 
         {children}
       </button>

--- a/src/components/TerminalHandler.tsx
+++ b/src/components/TerminalHandler.tsx
@@ -39,7 +39,7 @@ const TerminalHandler = () => {
           setOutput((prev) => [
             ...prev,
             <span key={Math.random()} className="font-mono text-lg">
-              <span className="font-bold text-green-500">{split[0]}</span>
+              <span className="font-bold text-terminal">{split[0]}</span>
               <span className="text-white">
                 {split.length > 1 ? " " + split.slice(1).join(" ") : ""}
               </span>
@@ -53,7 +53,7 @@ const TerminalHandler = () => {
         setOutput((prev) => [
           ...prev,
           <span key={Math.random()} className="font-mono text-lg">
-            <span className="font-bold text-green-500">{split[0]}</span>
+            <span className="font-bold text-terminal">{split[0]}</span>
             <span className="text-white">
               {split.length > 1 ? " " + split.slice(1).join(" ") : ""}
             </span>
@@ -83,7 +83,7 @@ const TerminalHandler = () => {
     }
     return (
       <>
-        <span className="font-bold text-green-500">{split[0]}</span>
+        <span className="font-bold text-terminal">{split[0]}</span>
         <span className="text-white">
           {split.length > 1 ? " " + split.slice(1).join(" ") : ""}
         </span>

--- a/src/components/commands/HelpCommand.tsx
+++ b/src/components/commands/HelpCommand.tsx
@@ -20,7 +20,7 @@ export const HelpCommand: Command = {
         <div className="text-cyan-400">Available commands:</div>
         {builtInCommands.map((cmd) => (
           <div key={cmd.name}>
-            <span className="text-green-400 font-bold">  ❯ {cmd.name.padEnd(12)}</span>
+            <span className="text-terminal font-bold">  ❯ {cmd.name.padEnd(12)}</span>
             <span className="text-gray-400 pr-5">{cmd.desc}</span>
             {cmd.args ? <span className="text-gray-400"><i>Args: [{cmd.args?.join(',')}]</i></span> : null}
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,10 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+    --terminal: #22c55e;
+}
+
 html, body {
     height: 100%;
     width: 100%;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import "./index.css";
 
 import { BrowserRouter } from "react-router";
 import { FullScreenHandler } from "./components/FullScreenHandler.js";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,7 +19,7 @@ export default {
         mono: ["JetBrains Mono", "monospace"],
       },
       colors: {
-          terminal: "#22c55e",
+        terminal: "var(--terminal)",
       }
     },
   },


### PR DESCRIPTION
## Summary
- export `./index.css` globally
- allow dynamic terminal color in Tailwind
- provide UI to pick a color
- replace green classes with terminal color
- render a palette icon that opens the color picker

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404d5696008323836d040577ad23f3