### PR TITLE
Add typing sounds in 3D terminal

### DIFF
--- a/src/components/terminal/TerminalCanvas.tsx
+++ b/src/components/terminal/TerminalCanvas.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, useEffect, useState } from "react";
 import * as THREE from "three";
 import TerminalHandler from "../TerminalHandler";
 import { KeyPressProvider } from "../../context/KeypressedContext";
+import useKeyClick from "../../hooks/useKeyClick";
 
 /* ---------- hook that returns a CanvasTexture driven by terminal lines ---------- */
 function useTerminalTexture(lines: string[]) {
@@ -102,8 +103,10 @@ function TerminalScene() {
 }
 
 export default function TerminalCanvas() {
+  const playClick = useKeyClick();
+
   return (
-    <KeyPressProvider>
+    <KeyPressProvider onKeyPress={playClick}>
       <div className="w-screen h-screen">
         <TerminalScene />
       </div>

--- a/src/context/KeypressedContext.tsx
+++ b/src/context/KeypressedContext.tsx
@@ -8,14 +8,19 @@ export type KeyPressContextType = {
 
 export const KeyPressContext = createContext<KeyPressContextType | null>(null);
 
-export const KeyPressProvider = ({ children }) => {
+export type KeyPressProviderProps = {
+  children: React.ReactNode;
+  onKeyPress?: (key: string, event: KeyboardEvent) => void;
+};
+
+export const KeyPressProvider = ({ children, onKeyPress }: KeyPressProviderProps) => {
   const [text, setText] = useState("");
 
   const clearText = () => {
     setText("");
   };
 
-  const handleKeyDown = (e) => {
+  const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key.length === 1) {
       setText((prev) => prev + e.key);
     } else if (e.key === "Backspace") {
@@ -23,6 +28,7 @@ export const KeyPressProvider = ({ children }) => {
     } else if (e.key === "Enter") {
       setText((prev) => prev + "\n");
     }
+    if (onKeyPress) onKeyPress(e.key, e);
   };
 
   useEffect(() => {

--- a/src/hooks/useKeyClick.ts
+++ b/src/hooks/useKeyClick.ts
@@ -1,0 +1,26 @@
+import { useCallback, useRef } from "react";
+
+export default function useKeyClick() {
+  const audioCtxRef = useRef<AudioContext>();
+
+  const play = useCallback(() => {
+    if (!audioCtxRef.current) {
+      audioCtxRef.current = new (window.AudioContext || (window as any).webkitAudioContext)();
+    }
+    const ctx = audioCtxRef.current;
+    if (ctx.state === "suspended") {
+      ctx.resume();
+    }
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = "square";
+    osc.frequency.value = 800;
+    gain.gain.value = 0.1;
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.05);
+  }, []);
+
+  return play;
+}


### PR DESCRIPTION
## Summary
- trigger sound callback from key press provider
- implement simple audio click hook
- use the hook in the 3D terminal

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842e0c02c60832392a9736b95edc9ff